### PR TITLE
feat: initialize ChannelService in layout component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,9 @@ import "./globals.css";
 import { AuthProvider } from "@/lib/auth";
 import { Navigation } from "@/components/navigation";
 import { Toaster } from "@/components/ui/sonner";
+import * as ChannelService from '@channel.io/channel-web-sdk-loader';
+
+ChannelService.loadScript()
 
 const geistSans = Geist({
   variable: "--font-geist-sans",


### PR DESCRIPTION
Add Channel.io web SDK script loader to enable chat functionality. The script is initialized at the root layout level to ensure availability across the application.